### PR TITLE
Allow footer style overrides

### DIFF
--- a/src/lib/features/Footer.stories.svelte
+++ b/src/lib/features/Footer.stories.svelte
@@ -10,3 +10,7 @@
 <Story name="Footer">
   <Footer />
 </Story>
+
+<Story name="FooterDark">
+  <Footer classes="bg-navy text-white border-opacity-25" />
+</Story>

--- a/src/lib/features/Footer.svelte
+++ b/src/lib/features/Footer.svelte
@@ -1,15 +1,18 @@
 <script lang="ts">
   import { FrequencyLogo, XLogo, DiscordLogo } from '../assets';
   import IconButton from '../atoms/IconButton.svelte';
+  import { cn } from '../utils/utils';
+
+  export let classes: string = '';
 </script>
 
-<footer class="sm md:md flex flex-col items-center gap-f16 border-t border-black py-f48 md:gap-f24">
+<footer class={cn('sm md:md flex flex-col items-center gap-f16 border-t border-black py-f48 md:gap-f24', classes)}>
   <div class="flex gap-f40">
     <a href="/privacy" class="underline transition duration-[0.3s] hover:text-brightBlue">Privacy Policy</a>
-    <a href="/terms" class="underline transition duration-[0.3s] hover:text-brightBlue">Terms of Conditions</a>
+    <a href="/terms" class="underline transition duration-[0.3s] hover:text-brightBlue">Terms and Conditions</a>
   </div>
   <FrequencyLogo class="w-[146px] md:w-[257px]" />
-  <aside>{`© ${new Date().getFullYear()} Frequency Network Foundation. All Right Reserved`}</aside>
+  <aside>{`© ${new Date().getFullYear()} Frequency Network Foundation. All Rights Reserved.`}</aside>
   <div class="flex gap-f16" aria-label="Social Links">
     <IconButton label="X/Twitter" href={'https://twitter.com/one_frequency'}>
       <XLogo />


### PR DESCRIPTION
# Problem

The Developer Portal has some pages that require a different "dark" styling for the Footer component.

# Solution

Added a "classes" property to the Footer component so that the styling can be overriden and merged in with the existing Tailwind classes. Also added a "FooterDark" storybook entry.

## Steps to Verify:

1. Pull branch
2. Run `npm run storybook`
3. Browse to Features->Footer->FooterDark to see the result. 

## Screenshots (optional):
![image](https://github.com/user-attachments/assets/0a28375d-ab29-49db-87d1-ea1a4b0fdce7)
