### PR TITLE
Center the footer text as well

### DIFF
--- a/src/lib/features/Footer.svelte
+++ b/src/lib/features/Footer.svelte
@@ -24,7 +24,7 @@
   )}
 >
   <FrequencyLogo class="w-[146px] md:w-[257px]" />
-  <aside class="flex flex-col items-center space-y-4 leading-none md:flex-row md:space-x-4 md:space-y-0">
+  <aside class="flex flex-col items-center space-y-4 text-center leading-none md:flex-row md:space-x-4 md:space-y-0">
     <div>
       © {new Date().getFullYear()} Frequency Network Foundation <span class="md:hidden">All Rights Reserved</span>
     </div>


### PR DESCRIPTION
# Problem

The footer text would not always center on very small screens

Before:
<img width="314" alt="image" src="https://github.com/user-attachments/assets/77dde976-d3f8-46b2-a363-742bf3c23a74">

After:
<img width="315" alt="image" src="https://github.com/user-attachments/assets/26cf7f70-c9a2-4b01-a3d5-f0070c585194">
