### PR TITLE
use `$$restProps` in Textarea atom

### DIFF
--- a/src/lib/atoms/Textarea.stories.svelte
+++ b/src/lib/atoms/Textarea.stories.svelte
@@ -46,5 +46,13 @@
     label: 'Textarea with Error',
   }}
 >
-  <Textarea {label} {placeholder} {isRequired} {value} {error} />
+  <Textarea {label} {placeholder} {isRequired} {value} {error}/>
+</Story>
+
+<!-- Extra classes Example -->
+<Story name="Textarea + Class"
+  args={{
+    label: "Textarea with extra classes"
+  }}>
+  <Textarea {label} {placeholder} {value} class="h-f160"></Textarea>
 </Story>

--- a/src/lib/atoms/Textarea.stories.svelte
+++ b/src/lib/atoms/Textarea.stories.svelte
@@ -46,13 +46,15 @@
     label: 'Textarea with Error',
   }}
 >
-  <Textarea {label} {placeholder} {isRequired} {value} {error}/>
+  <Textarea {label} {placeholder} {isRequired} {value} {error} />
 </Story>
 
 <!-- Extra classes Example -->
-<Story name="Textarea + Class"
+<Story
+  name="Textarea + Class"
   args={{
-    label: "Textarea with extra classes"
-  }}>
+    label: 'Textarea with extra classes',
+  }}
+>
   <Textarea {label} {placeholder} {value} class="h-f160"></Textarea>
 </Story>

--- a/src/lib/atoms/Textarea.svelte
+++ b/src/lib/atoms/Textarea.svelte
@@ -14,7 +14,8 @@
   <textarea
     class={cn(
       'border-input aria-[invalid]:border-destructive data-[placeholder]:[&>span]:text-muted-foreground sm flex h-10 w-full max-w-[388px] items-center justify-between rounded-md border bg-white px-3 py-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
-      error ? 'border-2 border-error' : 'border border-gray3'
+      error ? 'border-2 border-error' : 'border border-gray3',
+      $$restProps.class
     )}
     {placeholder}
     bind:value


### PR DESCRIPTION
# Problem
The `Textarea` atom in the style guide did not use `$$restProps.class`, so you could not do any class overrides, such as specifying a height.  It is passed to other components, like `Input`.

# Solution
Add `$$restProps.class` to the `cn(...)`.

## Steps to Verify:
```shell
git fetch && git checkout feat/use-restProps-textarea
npm run storybook
```

## Screenshots (optional):
<img width="765" alt="Screenshot 2024-11-13 at 3 15 02 PM" src="https://github.com/user-attachments/assets/2dc42f49-21c2-422f-a0ba-cc5872ac5c74">
