### PR TITLE
update accordion to be able to render a snippet

### DIFF
--- a/src/lib/features/Accordion.svelte
+++ b/src/lib/features/Accordion.svelte
@@ -1,17 +1,27 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import { Root, Item, Trigger, Content } from '../shadcnComponents/ui/accordion';
 
   interface Props {
-    trigger?: string;
-    content?: string;
+    trigger: string;
+    content: string | Snippet;
   }
 
-  let { trigger = '', content = '' }: Props = $props();
+  let { trigger, content }: Props = $props();
+
+  console.log(content);
+  console.log(typeof content);
 </script>
 
 <Root>
   <Item value="item-1">
     <Trigger>{trigger}</Trigger>
-    <Content>{content}</Content>
+    <Content
+      >{#if typeof content === 'function'}
+        {@render content()}
+      {:else}
+        {content}
+      {/if}</Content
+    >
   </Item>
 </Root>

--- a/src/lib/features/Accordion.svelte
+++ b/src/lib/features/Accordion.svelte
@@ -8,9 +8,6 @@
   }
 
   let { trigger, content }: Props = $props();
-
-  console.log(content);
-  console.log(typeof content);
 </script>
 
 <Root>

--- a/src/lib/features/AccordionList.stories.svelte
+++ b/src/lib/features/AccordionList.stories.svelte
@@ -7,6 +7,22 @@
   const { Story } = defineMeta({ title: 'UI Components/Features/AccordionList', component: AccordionList });
 </script>
 
+{#snippet htmlContent1()}
+  <div class="bg-teal">
+    <h2>Hello there.</h2>
+    <b>Nice to see ya!!</b>
+  </div>
+{/snippet}
+
+{#snippet htmlContent2()}
+  <h2>Yes I am!</h2>
+  <ul>
+    <li>Item 1</li>
+    <li>Item 2</li>
+    <li>Item 3</li>
+  </ul>
+{/snippet}
+
 <!-- Primary -->
 <Story name="Primary" id="accordionlist">
   <AccordionList>
@@ -14,5 +30,15 @@
   </AccordionList>
   <AccordionList>
     <Accordion trigger="Are you there?" content="Yes I am!" />
+  </AccordionList>
+</Story>
+
+<!-- With HTML Content -->
+<Story name="HTMLContent" id="accordionlistHtmlContent">
+  <AccordionList>
+    <Accordion trigger="Hello world." content={htmlContent1} />
+  </AccordionList>
+  <AccordionList>
+    <Accordion trigger="Are you there?" content={htmlContent2} />
   </AccordionList>
 </Story>


### PR DESCRIPTION
# Problem

Needs to be able to render HTML content in the accordion.

closes #87 

# Solution

- Change type of content to be able to handle a snippet rather than just string.
- Create storybook to display this feature.

## Steps to Verify:

1. See that the snippet is rendering as expected in the accordion in the storybook.

## Screenshots (optional):

https://github.com/user-attachments/assets/7882076e-7b44-4f0d-aedc-084687157209


