### PR TITLE
fix header colors, fix types, fix breakpoints

### DIFF
--- a/src/lib/atoms/IconButton.svelte
+++ b/src/lib/atoms/IconButton.svelte
@@ -2,7 +2,7 @@
   import type { HTMLAttributes } from 'svelte/elements';
   import { cn } from '../utils/utils';
 
-  interface Props extends HTMLAttributes<HTMLElement> {
+  interface Props extends HTMLAttributes<HTMLAnchorElement> {
     label?: string;
     href?: string;
     isRound?: boolean;

--- a/src/lib/atoms/Input.svelte
+++ b/src/lib/atoms/Input.svelte
@@ -3,7 +3,7 @@
   import FormElement from './FormElement.svelte';
   import type { HTMLAttributes } from 'svelte/elements';
 
-  interface Props extends HTMLAttributes<HTMLElement> {
+  interface Props extends HTMLAttributes<HTMLInputElement> {
     label?: string;
     isRequired?: boolean;
     description?: string;
@@ -25,7 +25,7 @@
   }: Props = $props();
 </script>
 
-<FormElement {label} {isRequired} {description} {error} {...rest}>
+<FormElement {label} {isRequired} {description} {error}>
   <input
     class={cn(
       'border-input aria-[invalid]:border-destructive [&>span]:data-placeholder:text-muted-foreground smText flex h-10 w-full max-w-[388px] items-center justify-between rounded-md border bg-white px-3 py-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
@@ -36,5 +36,6 @@
     {placeholder}
     {disabled}
     bind:value
+    {...rest}
   />
 </FormElement>

--- a/src/lib/atoms/Textarea.svelte
+++ b/src/lib/atoms/Textarea.svelte
@@ -3,7 +3,7 @@
   import FormElement from './FormElement.svelte';
   import type { HTMLAttributes } from 'svelte/elements';
 
-  interface Props extends HTMLAttributes<HTMLElement> {
+  interface Props extends HTMLAttributes<HTMLTextAreaElement> {
     label?: string;
     isRequired?: boolean;
     description?: string;
@@ -25,6 +25,7 @@
 
 <FormElement {label} {isRequired} {description} {error}>
   <textarea
+    {...rest}
     class={cn(
       'border-input aria-[invalid]:border-destructive [&>span]:data-placeholder:text-muted-foreground sm flex h-10 w-full max-w-[388px] items-center justify-between rounded-md border bg-white px-3 py-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
       error ? 'border-error border-2' : 'border-gray3 border',

--- a/src/lib/features/NavMenu.svelte
+++ b/src/lib/features/NavMenu.svelte
@@ -45,7 +45,7 @@
   });
 </script>
 
-<nav class="gap-f32 text-primary font-title xs:hidden md:flex">
+<nav class="gap-f32 text-primary font-title xs:hidden lg:flex">
   {#each menuItems as item, index (index)}
     {#if item.isButton}
       <div class="content-center">
@@ -62,7 +62,7 @@
       <a
         href={item.href}
         target={item.isExternal ? '_blank' : '_self'}
-        class={`h6 text-primary border-color xs:hidden relative cursor-pointer content-center overflow-hidden px-2 transition-all duration-1000 after:absolute after:bottom-0 after:left-0 after:h-[13px] after:w-full after:transform after:bg-current after:opacity-0 after:transition-opacity after:content-[''] lg:block ${
+        class={`h6 text-navy border-color xs:hidden after:bg-teal relative cursor-pointer content-center overflow-hidden px-2 transition-all duration-1000 after:absolute after:bottom-0 after:left-0 after:h-[13px] after:w-full after:transform after:opacity-0 after:transition-opacity after:content-[''] lg:block ${
           item.viewportHighlightId && highlightId === item.viewportHighlightId
             ? 'after:translate-y-0 after:opacity-100'
             : 'after:translate-y-[200%]'


### PR DESCRIPTION
# Problem
- bugs from latest release

# Solution
- fix header breakpoints
- fix header underline color
- header text color to match logo
- fix types in `extends` props

## Steps to Verify:

1. Make sure header looks as expected in all screen sizes.

## Screenshots (optional):

