### PR TITLE
Remove extra import that triggers duplicate css files in vite

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -18,6 +18,3 @@ export { default as NavMenuMobile } from './features/NavMenuMobile.svelte';
 
 // icons & logos
 export * as Assets from './design-system/assets/index';
-
-// css styles
-import './styles/index.css';


### PR DESCRIPTION
# Problem

In Vite, the import here was triggering a second additional index file to be generated. Instead have file imported in CSS as the README.md specifies.

# Solution

Removed the extra import

## Steps to Verify:

1. Style Guide package: `npm run build && cd dist && npm pack`
2. Style Guide using (Provider Dashboard for example)
3. Before: See that the styles are duplicated when building
4. After installed the tarball: See just one set of styles.