### PR TITLE
Include import and require in the . exports list

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ npm i @frequency-chain/style-guide
 3. Edit your `app.css` file to import the style guide and set the source.
 
 ```css
-@import '@frequency-chain/style-guide';
+@import '@frequency-chain/style-guide/styles';
 
 @source '../../node_modules/@frequency-chain/style-guide/**/*.{svelte,js,ts}';
 ```
 
 You should now be able to access the Frequency Style Guide Tailwind theme and custom css classes in your Svelte
-components!
+components! (Make sure you update the path to the `node_modules` if it is different than above.)
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -10,12 +10,10 @@
       "import": "./dist/index.js",
       "require": "./dist/index.js",
       "types": "./dist/index.d.ts",
-      "svelte": "./dist/index.js",
-      "style": "./dist/styles/index.css"
+      "svelte": "./dist/index.js"
     },
     "./styles": "./dist/styles/index.css"
   },
-  "style": "./src/lib/styles/index.css",
   "scripts": {
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",

--- a/scripts/package.cjs
+++ b/scripts/package.cjs
@@ -20,12 +20,9 @@ rootPackage.exports = {
     require: './index.js',
     types: './index.d.ts',
     svelte: './index.js',
-    style: './styles/index.css',
   },
   './styles': './styles/index.css',
 };
-
-rootPackage.style = './styles/index.css';
 
 // Don't keep dev dependencies
 delete rootPackage['devDependencies'];


### PR DESCRIPTION
# Problem

Vite is strict about resolving imports when exports is defined and this adds the needed exports.

## Solution

Exports defined.