### PR TITLE
add id to modal

### DIFF
--- a/src/lib/features/Modal.stories.svelte
+++ b/src/lib/features/Modal.stories.svelte
@@ -20,7 +20,7 @@
   </div>
 {/snippet}
 
-<Story name="Default Modal" args={{ ...Modal.props, title, description, trigger, body }}>
+<Story name="Default Modal" args={{ ...Modal.props, title, description, trigger, body, id: '' }}>
   {#snippet children(args)}
     <Modal {...args} />
   {/snippet}

--- a/src/lib/features/Modal.svelte
+++ b/src/lib/features/Modal.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import type { DialogProps } from 'bits-ui';
   import { Root, Trigger, Content, Header, Title, Description } from '../shadcnComponents/ui/dialog';
+  import type { HTMLAttributes } from 'svelte/elements';
 
-  interface Props extends DialogProps {
+  interface Props extends DialogProps, HTMLAttributes<HTMLElement> {
     title?: string;
     description?: string;
     trigger?: import('svelte').Snippet;
@@ -16,7 +17,7 @@
   <Trigger>
     {@render trigger?.()}
   </Trigger>
-  <Content>
+  <Content id={rest.id}>
     <Header>
       <Title>{title}</Title>
       {#if description}


### PR DESCRIPTION
# Problem
- need to add `id` to modal for testing and provider dashboard support

# Solution
- add id to props
