### PR TITLE
133 feature

### DIFF
--- a/src/lib/design-system/Typography.stories.svelte
+++ b/src/lib/design-system/Typography.stories.svelte
@@ -34,3 +34,9 @@
   <Typography class="xsText">Body Xs</Typography>
   <Typography class="xsText" bold={true}>Body Xs Bold</Typography>
 </Story>
+
+<Story name="Docs">
+  <div class="docsHeaderText">docsHeaderText</div>
+  <div class="docsSubHeaderText" bold={true}>docsSubHeaderText</div>
+  <div class="docsBodyText">docsBodyText</div>
+</Story>

--- a/src/lib/styles/index.css
+++ b/src/lib/styles/index.css
@@ -178,7 +178,7 @@
 }
 
 @utility docsBodyText {
-  @apply text-sm leading-sm;
+  @apply leading-sm text-sm;
 }
 
 /* Misc */

--- a/src/lib/styles/index.css
+++ b/src/lib/styles/index.css
@@ -77,17 +77,17 @@
 
   /* Line Heights */
   --spacing-default: 22px;
-  --spacing-h0: 70px;
+  --spacing-h0: 91px;
   --spacing-h1: 61px;
   --spacing-h2: 52px;
   --spacing-h3: 44px;
   --spacing-h4: 35px;
-  --spacing-h5: 26px;
+  --spacing-h5: 30px;
   --spacing-h6: 22px;
   --spacing-lg: 30px;
   --spacing-md: 25px;
   --spacing-normal: 22px;
-  --spacing-sm: 16px;
+  --spacing-sm: 20px;
   --spacing-xs: 14px;
 
   /* Spacing */
@@ -154,7 +154,6 @@
 
 @utility mdText {
   @apply text-md leading-md;
-  @apply text-md leading-md;
 }
 
 @utility normalText {
@@ -169,6 +168,20 @@
   @apply leading-xs text-xs;
 }
 
+/* Docs Utilities */
+@utility docsHeaderText {
+  @apply text-h5 leading-h5 font-bold;
+}
+
+@utility docsSubHeaderText {
+  @apply text-h6 leading-h6;
+}
+
+@utility docsBodyText {
+  @apply text-sm leading-sm;
+}
+
+/* Misc */
 @utility underline-on-hover {
   /* Underline on hover animation */
   @apply relative block cursor-pointer overflow-hidden px-0 py-1;


### PR DESCRIPTION
# Problem
Need to have docs text conventions

GitHub Issue(s): #133 

# Solution

- add utility

## Screenshots (optional):

<img width="826" height="575" alt="Screenshot 2025-10-06 at 12 55 56 PM" src="https://github.com/user-attachments/assets/d5406e96-32e6-4a37-995d-9184488c4e30" />
